### PR TITLE
Feat: create tables for manage subjects

### DIFF
--- a/prisma/migrations/20250412000125_create_tables_for_subjects/migration.sql
+++ b/prisma/migrations/20250412000125_create_tables_for_subjects/migration.sql
@@ -1,0 +1,44 @@
+-- CreateTable
+CREATE TABLE "subjects" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "subjects_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "topics" (
+    "id" TEXT NOT NULL,
+    "subject_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "position" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "topics_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "contents" (
+    "id" TEXT NOT NULL,
+    "topic_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "publication_date" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "contents_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "topics" ADD CONSTRAINT "topics_subject_id_fkey" FOREIGN KEY ("subject_id") REFERENCES "subjects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "contents" ADD CONSTRAINT "contents_topic_id_fkey" FOREIGN KEY ("topic_id") REFERENCES "topics"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,3 +51,46 @@ model Session {
 
   @@map("sessions")
 }
+
+model Subject {
+  id          String   @id @default(uuid())
+  name        String
+  description String
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @default(now()) @map("updated_at")
+
+  topics Topic[]
+
+  @@map("subjects")
+}
+
+model Topic {
+  id          String   @id @default(uuid())
+  subjectId   String   @map("subject_id")
+  name        String
+  description String
+  position    Int
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @default(now()) @map("updated_at")
+
+  subject Subject   @relation(fields: [subjectId], references: [id], onDelete: Cascade)
+  Content Content[]
+
+  @@map("topics")
+}
+
+model Content {
+  id              String   @id @default(uuid())
+  topicId         String   @map("topic_id")
+  name            String
+  description     String
+  url             String
+  type            String
+  publicationDate DateTime @map("publication_date")
+  createdAt       DateTime @default(now()) @map("created_at")
+  updatedAt       DateTime @default(now()) @map("updated_at")
+
+  topic Topic @relation(fields: [topicId], references: [id], onDelete: Cascade)
+
+  @@map("contents")
+}


### PR DESCRIPTION
This pull request includes significant changes to the database schema by adding new tables and models for subjects, topics, and contents. The changes ensure proper relationships and constraints between these entities.

Schema and Migration Changes:

* [`prisma/migrations/20250412000125_create_tables_for_subjects/migration.sql`](diffhunk://#diff-8b151a196ff9f2206a62f0c023351dff92fa67f8f49a8fd8b6755d51b631de73R1-R44): Added new tables `subjects`, `topics`, and `contents` with appropriate fields and constraints, including foreign key relationships.

Model Definitions:

* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR54-R96): Introduced new models `Subject`, `Topic`, and `Content` to represent the new tables, with fields mapped to the corresponding database columns and relationships defined.