### PR TITLE
Feat: create tables for manage last access

### DIFF
--- a/prisma/migrations/20250412020330_create_tables_for_manage_last_access/migration.sql
+++ b/prisma/migrations/20250412020330_create_tables_for_manage_last_access/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE "subject_access" (
+    "user_id" TEXT NOT NULL,
+    "subject_id" TEXT NOT NULL,
+    "last_access" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "subject_access_pkey" PRIMARY KEY ("user_id","subject_id")
+);
+
+-- CreateTable
+CREATE TABLE "content_access" (
+    "user_id" TEXT NOT NULL,
+    "content_id" TEXT NOT NULL,
+    "last_access" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "content_access_pkey" PRIMARY KEY ("user_id","content_id")
+);
+
+-- AddForeignKey
+ALTER TABLE "subject_access" ADD CONSTRAINT "subject_access_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "subject_access" ADD CONSTRAINT "subject_access_subject_id_fkey" FOREIGN KEY ("subject_id") REFERENCES "subjects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "content_access" ADD CONSTRAINT "content_access_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "content_access" ADD CONSTRAINT "content_access_content_id_fkey" FOREIGN KEY ("content_id") REFERENCES "contents"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,8 +24,10 @@ model User {
   updatedAt     DateTime  @default(now()) @map("updated_at")
   lastAppAccess DateTime? @map("last_app_access")
 
-  Session Session[]
-  role    Role      @relation(fields: [roleId], references: [id])
+  Session       Session[]
+  role          Role            @relation(fields: [roleId], references: [id])
+  SubjectAccess SubjectAccess[]
+  ContentAccess ContentAccess[]
 
   @@map("users")
 }
@@ -59,7 +61,8 @@ model Subject {
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @default(now()) @map("updated_at")
 
-  topics Topic[]
+  topics        Topic[]
+  SubjectAccess SubjectAccess[]
 
   @@map("subjects")
 }
@@ -90,7 +93,32 @@ model Content {
   createdAt       DateTime @default(now()) @map("created_at")
   updatedAt       DateTime @default(now()) @map("updated_at")
 
-  topic Topic @relation(fields: [topicId], references: [id], onDelete: Cascade)
+  topic         Topic           @relation(fields: [topicId], references: [id], onDelete: Cascade)
+  ContentAccess ContentAccess[]
 
   @@map("contents")
+}
+
+model SubjectAccess {
+  userId     String   @map("user_id")
+  subjectId  String   @map("subject_id")
+  lastAccess DateTime @map("last_access")
+
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  subject Subject @relation(fields: [subjectId], references: [id], onDelete: Cascade)
+
+  @@id([userId, subjectId])
+  @@map("subject_access")
+}
+
+model ContentAccess {
+  userId     String   @map("user_id")
+  contentId  String   @map("content_id")
+  lastAccess DateTime @map("last_access")
+
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  content Content @relation(fields: [contentId], references: [id], onDelete: Cascade)
+
+  @@id([userId, contentId])
+  @@map("content_access")
 }


### PR DESCRIPTION
This pull request introduces new tables and relationships to manage last access times for subjects and content. The changes include creating new tables in the database and updating the Prisma schema to reflect these additions.

Database schema changes:

* [`prisma/migrations/20250412020330_create_tables_for_manage_last_access/migration.sql`](diffhunk://#diff-0ea7a3ef2d4fdbabb1b68ab7720747d5c61ebb17ad9566ee46db23cc8daa66e6R1-R29): Created `subject_access` and `content_access` tables to store last access times for subjects and content, respectively. Added foreign key constraints to ensure referential integrity.

Prisma schema updates:

* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR29-R30): Updated the `User` model to include relations to the new `SubjectAccess` and `ContentAccess` models.
* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR65): Updated the `Subject` model to include a relation to the new `SubjectAccess` model.
* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR97-R124): Updated the `Content` model to include a relation to the new `ContentAccess` model.
* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR97-R124): Added `SubjectAccess` and `ContentAccess` models to map the new tables and their relationships.